### PR TITLE
Explicit loop parameter for current_task() function

### DIFF
--- a/aiotask_context/__init__.py
+++ b/aiotask_context/__init__.py
@@ -13,7 +13,7 @@ def task_factory(loop, coro):
         del task._source_traceback[-1]
 
     try:
-        task.context = asyncio.Task.current_task().context
+        task.context = asyncio.Task.current_task(loop=loop).context
     except AttributeError:
         task.context = {}
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -47,10 +47,10 @@ class TestContext:
     def test_loop_bug_aiohttp(self, event_loop):
 
         @asyncio.coroutine
-        def coro():
-            yield from asyncio.ensure_future(asyncio.sleep(0))
+        def coro(loop):
+            yield from asyncio.sleep(0, loop=loop)
             return True
 
-        assert event_loop.run_until_complete(coro()) is True
+        assert event_loop.run_until_complete(coro(event_loop)) is True
         asyncio.set_event_loop(None)
-        assert event_loop.run_until_complete(coro()) is True
+        assert event_loop.run_until_complete(coro(event_loop)) is True

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -43,3 +43,14 @@ class TestContext:
     def test_set_without_loop(self):
         with pytest.raises(ValueError):
             context.set("random", "value")
+
+    def test_loop_bug_aiohttp(self, event_loop):
+
+        @asyncio.coroutine
+        def coro():
+            yield from asyncio.ensure_future(asyncio.sleep(0))
+            return True
+
+        assert event_loop.run_until_complete(coro()) is True
+        asyncio.set_event_loop(None)
+        assert event_loop.run_until_complete(coro()) is True


### PR DESCRIPTION
Raised because of a bug in the aiohttp pytest helpers