### PR TITLE
Fix for uvloop

### DIFF
--- a/aiotask_context/__init__.py
+++ b/aiotask_context/__init__.py
@@ -6,10 +6,6 @@ logger = logging.getLogger(__name__)
 
 
 def task_factory(loop, coro):
-    # For uvloop loop._check_closed is private
-    if loop.is_closed():
-        raise RuntimeError('Event loop is closed')
-
     task = asyncio.tasks.Task(coro, loop=loop)
     if task._source_traceback:
         del task._source_traceback[-1]

--- a/aiotask_context/__init__.py
+++ b/aiotask_context/__init__.py
@@ -6,8 +6,10 @@ logger = logging.getLogger(__name__)
 
 
 def task_factory(loop, coro):
+    # For uvloop loop._check_closed is private
+    if loop.is_closed():
+        raise RuntimeError('Event loop is closed')
 
-    loop._check_closed()
     task = asyncio.tasks.Task(coro, loop=loop)
     if task._source_traceback:
         del task._source_traceback[-1]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -54,3 +54,9 @@ class TestContext:
         assert event_loop.run_until_complete(coro(event_loop)) is True
         asyncio.set_event_loop(None)
         assert event_loop.run_until_complete(coro(event_loop)) is True
+
+
+    def test_closed_loop(self, event_loop):
+        event_loop.close()
+        with pytest.raises(RuntimeError):
+            context.task_factory(event_loop, dummy())

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -55,7 +55,6 @@ class TestContext:
         asyncio.set_event_loop(None)
         assert event_loop.run_until_complete(coro(event_loop)) is True
 
-
     def test_closed_loop(self, event_loop):
         event_loop.close()
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
Seems the original motivation was reusing code from `_check_closed`, but this doesn't work with uvloop.