### PR TITLE
Adds copying_task_factory and tests

### DIFF
--- a/aiotask_context/__init__.py
+++ b/aiotask_context/__init__.py
@@ -1,24 +1,40 @@
 import asyncio
 import logging
+from copy import deepcopy
 
 
 logger = logging.getLogger(__name__)
 
-
 NO_LOOP_EXCEPTION_MSG = "No event loop found, key {} couldn't be set"
 
 
-def task_factory(loop, coro):
+def task_factory(loop, coro, copy_context=False):
     task = asyncio.tasks.Task(coro, loop=loop)
     if task._source_traceback:
         del task._source_traceback[-1]
 
     try:
-        task.context = asyncio.Task.current_task(loop=loop).context
+        context = asyncio.Task.current_task(loop=loop).context
+        if copy_context:
+            context = deepcopy(context)
+
+        task.context = context
     except AttributeError:
         task.context = {}
 
     return task
+
+
+def copying_task_factory(loop, coro):
+    """
+    Returns a task factory that copies a task's context into new tasks instead of
+    sharing it.
+
+    :param loop: The active event loop
+    :param coro: A coroutine object
+    :return: A context copying task factory
+    """
+    return task_factory(loop, coro, copy_context=True)
 
 
 def get(key, default=None):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -82,3 +82,17 @@ class TestTaskFactory:
         task.cancel()
 
         assert isinstance(task._source_traceback, traceback.StackSummary)
+
+    @pytest.mark.asyncio
+    async def test_propagates_copy_of_context(self, event_loop):
+        @asyncio.coroutine
+        def adds_to_context():
+            context.set('foo', 'bar')
+            return True
+
+        context.set('key', 'value')
+        task = context.copying_task_factory(event_loop, adds_to_context())
+        await task
+
+        assert task.context == {'key': 'value', 'foo': 'bar'}
+        assert context.get('foo') is None


### PR DESCRIPTION
The copying_task_factory does not share the context
when creating new tasks and uses a copy of it.
This is to allow created tasks to modify their context
without mirroring the change into every other task, but
whilst still passing along a copy of their own context
to their children.