### PR TITLE
Added usage of ChainMap as the context object

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ if __name__ == '__main__':
     loop = asyncio.get_event_loop()
     for factory in (context.copying_task_factory,
                     context.chainmap_task_factory):
-        print('\nUisng', factory.__name__)
+        print('\nUsing', factory.__name__)
         loop.set_task_factory(factory)  # This is the relevant line
         loop.run_until_complete(my_coro_spawner())
 ```
@@ -178,7 +178,7 @@ if __name__ == '__main__':
     for factory in (context.task_factory,
                     context.copying_task_factory,
                     context.chainmap_task_factory):
-        print('\nUisng', factory.__name__)
+        print('\nUsing', factory.__name__)
         loop.set_task_factory(factory)
         loop.run_until_complete(my_coro_parent(loop))
 ```
@@ -186,17 +186,17 @@ if __name__ == '__main__':
 In this case the results are different for all three:
 
 ```
-Uisng task_factory
+Using task_factory
 parent before: simple=from parent, complex=['from', 'parent']
 child: simple=from child, complex=['from', 'child']
 parent after: simple=from child, complex=['from', 'child']
 
-Uisng copying_task_factory
+Using copying_task_factory
 parent before: simple=from parent, complex=['from', 'parent']
 child: simple=from child, complex=['from', 'child']
 parent after: simple=from parent, complex=['from', 'parent']
 
-Uisng chainmap_task_factory
+Using chainmap_task_factory
 parent before: simple=from parent, complex=['from', 'parent']
 child: simple=from child, complex=['from', 'child']
 parent after: simple=from parent, complex=['from', 'child']

--- a/README.md
+++ b/README.md
@@ -102,8 +102,16 @@ if __name__ == '__main__':
     loop.run_until_complete(my_coro_2())
 ```
 
-You may also want to only keep a copy of the context between calls. For example, you have one task that spawns many others and do not want to reflect changes in one task's context into the other tasks.
-To do this use the copying_task_context:
+You may also want to only keep a copy of the context between calls.
+For example, you have one task that spawns many others
+and do not want to reflect changes in one task's context into the other tasks.
+To do this you have two options:
+
+- `copying_task_factory` - uses a brand new copy of the context `dict` for *each* task
+- `chainmap_task_factory` - uses a `ChainMap` instead of a `dict` as context,
+    which allows some of the values to be redefined while not creating a full copy of the context
+
+The following example yields the same results with both:
 
 ```python
 import asyncio
@@ -132,10 +140,67 @@ async def my_coro_spawner():
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()
-    loop.set_task_factory(context.copying_task_factory)  # This is the relevant line
-    loop.run_until_complete(my_coro_spawner())
+    for factory in (context.copying_task_factory,
+                    context.chainmap_task_factory):
+        print('\nUisng', factory.__name__)
+        loop.set_task_factory(factory)  # This is the relevant line
+        loop.run_until_complete(my_coro_spawner())
 ```
 
+## Comparison of task factories / context types
+
+The difference between the task factories can be best illustrated by
+how they behave when inherited values are redefined or updated in child tasks.
+
+Consider:
+
+```python
+import asyncio
+import aiotask_context as context
+
+async def my_coro_parent(loop):
+    context.set("simple", "from parent")
+    context.set("complex", ["from", "parent"])
+    print("parent before: simple={}, complex={}".format(
+        context.get("simple"), context.get("complex")))
+    await loop.create_task(my_coro_child())
+    print("parent after: simple={}, complex={}".format(
+        context.get("simple"), context.get("complex")))
+
+async def my_coro_child():
+    context.set("simple", "from child")  # redefine value completely
+    context.get("complex")[1] = "child"  # update existing object
+    print("child: simple={}, complex={}".format(
+        context.get("simple"), context.get("complex")))
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    for factory in (context.task_factory,
+                    context.copying_task_factory,
+                    context.chainmap_task_factory):
+        print('\nUisng', factory.__name__)
+        loop.set_task_factory(factory)
+        loop.run_until_complete(my_coro_parent(loop))
+```
+
+In this case the results are different for all three:
+
+```
+Uisng task_factory
+parent before: simple=from parent, complex=['from', 'parent']
+child: simple=from child, complex=['from', 'child']
+parent after: simple=from child, complex=['from', 'child']
+
+Uisng copying_task_factory
+parent before: simple=from parent, complex=['from', 'parent']
+child: simple=from child, complex=['from', 'child']
+parent after: simple=from parent, complex=['from', 'parent']
+
+Uisng chainmap_task_factory
+parent before: simple=from parent, complex=['from', 'parent']
+child: simple=from child, complex=['from', 'child']
+parent after: simple=from parent, complex=['from', 'child']
+```
 
 ## Complete examples
 

--- a/aiotask_context/__init__.py
+++ b/aiotask_context/__init__.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+from collections import ChainMap
+from functools import partial
 from copy import deepcopy
 
 
@@ -8,19 +10,55 @@ logger = logging.getLogger(__name__)
 NO_LOOP_EXCEPTION_MSG = "No event loop found, key {} couldn't be set"
 
 
-def task_factory(loop, coro, copy_context=False):
+def dict_context_factory(parent_context=None, copy_context=False):
+    """A traditional ``dict`` context to keep things simple"""
+    if parent_context is None:
+        # initial context
+        return {}
+    else:
+        # inherit context
+        new_context = parent_context
+        if copy_context:
+            new_context = deepcopy(new_context)
+        return new_context
+
+
+def chainmap_context_factory(parent_context=None):
+    """
+    A ``ChainMap`` context, to avoid copying any data
+    and yet preserve strict one-way inheritance
+    (just like with dict copying)
+    """
+    if parent_context is None:
+        # initial context
+        return ChainMap()
+    else:
+        # inherit context
+        if not isinstance(parent_context, ChainMap):
+            # if a dict context was previously used, then convert
+            # (without modifying the original dict)
+            parent_context = ChainMap(parent_context)
+        return parent_context.new_child()
+
+
+def task_factory(loop, coro, copy_context=False, context_factory=None):
+    """
+    By default returns a task factory that uses a simple dict as the task context,
+    but allows context creation and inheritance to be customized via ``context_factory``.
+    """
+    context_factory = context_factory or partial(
+        dict_context_factory, copy_context=copy_context)
+
     task = asyncio.tasks.Task(coro, loop=loop)
     if task._source_traceback:
         del task._source_traceback[-1]
 
     try:
         context = asyncio.Task.current_task(loop=loop).context
-        if copy_context:
-            context = deepcopy(context)
-
-        task.context = context
     except AttributeError:
-        task.context = {}
+        context = None
+
+    task.context = context_factory(context)
 
     return task
 
@@ -32,9 +70,20 @@ def copying_task_factory(loop, coro):
 
     :param loop: The active event loop
     :param coro: A coroutine object
-    :return: A context copying task factory
+    :return: A context-copying task factory
     """
     return task_factory(loop, coro, copy_context=True)
+
+
+def chainmap_task_factory(loop, coro):
+    """
+    Returns a task factory that uses ``ChainMap`` as the context.
+
+    :param loop: The active event loop
+    :param coro: A coroutine object
+    :return: A ``ChainMap`` task factory
+    """
+    return task_factory(loop, coro, context_factory=chainmap_context_factory)
 
 
 def get(key, default=None):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -96,3 +96,17 @@ class TestTaskFactory:
 
         assert task.context == {'key': 'value', 'foo': 'bar'}
         assert context.get('foo') is None
+
+    @pytest.mark.asyncio
+    async def test_propagates_chainmap_context(self, event_loop):
+        @asyncio.coroutine
+        def adds_to_context():
+            context.set('foo', 'bar')
+            return True
+
+        context.set('key', 'value')
+        task = context.chainmap_task_factory(event_loop, adds_to_context())
+        await task
+
+        assert task.context == {'key': 'value', 'foo': 'bar'}
+        assert context.get('foo') is None


### PR DESCRIPTION
Added support for ChainMap as the context object.

This way there's no need to copy any data, which can get painful in at least two cases:
1. if you have some complex objects in the base context - deepcopy becomes not a very good idea
2. you have a LOT of tasks inheriting from the main one (or even going deeper) - still results in a lot of extra data in memory

all this while preserving correct context inheritance behavior