### PR TITLE
fixed:python3.11 TypeError: task_factory() got an unexpected keyword argument 'context'

### DIFF
--- a/aiotask_context/__init__.py
+++ b/aiotask_context/__init__.py
@@ -55,7 +55,7 @@ def chainmap_context_factory(parent_context=None):
         return parent_context.new_child()
 
 
-def task_factory(loop, coro, copy_context=False, context_factory=None):
+def task_factory(loop, coro, context=None, copy_context=False, context_factory=None):
     """
     By default returns a task factory that uses a simple dict as the task context,
     but allows context creation and inheritance to be customized via ``context_factory``.
@@ -63,7 +63,7 @@ def task_factory(loop, coro, copy_context=False, context_factory=None):
     context_factory = context_factory or partial(
         dict_context_factory, copy_context=copy_context)
 
-    task = asyncio.tasks.Task(coro, loop=loop)
+    task = asyncio.tasks.Task(coro, loop=loop, context=context)
     if task._source_traceback:
         del task._source_traceback[-1]
 
@@ -77,7 +77,7 @@ def task_factory(loop, coro, copy_context=False, context_factory=None):
     return task
 
 
-def copying_task_factory(loop, coro):
+def copying_task_factory(loop, coro, context=None):
     """
     Returns a task factory that copies a task's context into new tasks instead of
     sharing it.
@@ -86,10 +86,10 @@ def copying_task_factory(loop, coro):
     :param coro: A coroutine object
     :return: A context-copying task factory
     """
-    return task_factory(loop, coro, copy_context=True)
+    return task_factory(loop, coro, context=context, copy_context=True)
 
 
-def chainmap_task_factory(loop, coro):
+def chainmap_task_factory(loop, coro, context=None):
     """
     Returns a task factory that uses ``ChainMap`` as the context.
 
@@ -97,7 +97,7 @@ def chainmap_task_factory(loop, coro):
     :param coro: A coroutine object
     :return: A ``ChainMap`` task factory
     """
-    return task_factory(loop, coro, context_factory=chainmap_context_factory)
+    return task_factory(loop, coro, context=context, context_factory=chainmap_context_factory)
 
 
 def get(key, default=None):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ tests_require = install_requires + ['pytest']
 
 setup(
     name="aiotask_context",
-    version="0.6.1",
+    version="0.6.2",
     author="Manuel Miranda",
     author_email="manu.mirandad@gmail.com",
     description="Store context information inside the asyncio.Task object",
@@ -14,6 +14,10 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     packages=['aiotask_context'],
     install_requires=install_requires,


### PR DESCRIPTION
In web project and python3.11.x, used example's code, it will raise the err:
 TypeError: task_factory() got an unexpected keyword argument 'context'